### PR TITLE
Add table pokemon_location. closes #2

### DIFF
--- a/docs/tables/pokemon_location.md
+++ b/docs/tables/pokemon_location.md
@@ -1,0 +1,16 @@
+# Table: pokemon_location
+
+Pokémon game gives us the flexibility to visit locations within the game. They make up sizeable proportions of regions like cities or routes.
+
+## Examples
+
+### Basic info
+
+```sql
+select
+  name,
+  id
+from
+  pokemon_location
+```
+

--- a/pokemon/plugin.go
+++ b/pokemon/plugin.go
@@ -13,6 +13,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 		DefaultTransform: transform.FromCamel(),
 		TableMap: map[string]*plugin.Table{
 			"pokemon_pokemon": tablePokemonPokemon(ctx),
+			"pokemon_location": tablePokemonLocation(ctx),
 		},
 	}
 	return p

--- a/pokemon/table_pokemon_location.go
+++ b/pokemon/table_pokemon_location.go
@@ -1,0 +1,127 @@
+package pokemon
+
+import (
+	"context"
+
+	"github.com/mtslzr/pokeapi-go"
+	"github.com/mtslzr/pokeapi-go/structs"
+
+	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/plugin/transform"
+)
+
+func tablePokemonLocation(ctx context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name: "pokemon_location",
+		Description:  "Locations that can be visited within the games. Locations make up sizable portions of regions, like cities or routes.",
+		List: &plugin.ListConfig{
+			Hydrate: listLocations,
+		},
+		Get: &plugin.GetConfig{
+			KeyColumns: plugin.AnyColumn([]string{"name"}),
+			Hydrate: getLocation,
+			ShouldIgnoreError: isNotFoundError([]string{"invalid character 'N' looking for beginning of value"}),			
+		},
+		Columns: []*plugin.Column{
+			{
+				Name:        "name",
+				Description: "The name for this resource.",
+				Type:        proto.ColumnType_STRING,				
+			},
+			{
+				Name:        "areas",
+				Description: "Areas that can be found in this location",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getLocation,
+			},
+			{
+				Name:        "game_indices",
+				Description: "A list of game indices relevant to location item by generation",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getLocation,
+			},
+			{
+				Name:        "id",
+				Description: "The identifier for this resource.",
+				Type:        proto.ColumnType_INT,
+				Hydrate:     getLocation,
+				Transform:   transform.FromGo(),
+			},
+
+			{
+				Name:        "names",
+				Description: "Name of the region in different languages",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getLocation,
+			},
+			// Standard columns
+			{
+				Name: 			"title",
+				Description: 	"Title of the resource.",
+				Type: 			proto.ColumnType_STRING,
+				Transform: 		transform.FromField("Name"),
+			},
+		},
+	}
+}
+
+func listLocations(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+	logger := plugin.Logger(ctx)
+	logger.Trace("listLocations")
+
+	offset := 0
+
+	for true {
+		resources, err := pokeapi.Resource("location", offset)
+
+		if err != nil {
+			plugin.Logger(ctx).Error("pokemon_location.listLocations", "query_error", err)
+			return nil, err
+		}
+
+		for _, pokemon := range resources.Results {
+			d.StreamListItem(ctx, pokemon)
+		}
+
+		// No next URL returned
+		if len(resources.Next) == 0 {
+			break
+		}
+
+		urlOffset, err := extractUrlOffset(resources.Next)
+		if err != nil {
+			plugin.Logger(ctx).Error("pokemon_location.listLocations", "extract_url_offset_error", err)
+			return nil, err
+		}
+
+		// Set next offset
+		offset = urlOffset
+	}
+	return nil, nil
+}
+
+func getLocation(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	logger := plugin.Logger(ctx)
+	logger.Trace("getLocation")
+
+	var name string
+
+	if h.Item != nil {
+		result := h.Item.(structs.Result)
+		name = result.Name
+	} else {
+		name = d.KeyColumnQuals["name"].GetStringValue()
+	}
+
+	logger.Debug("Name", name)
+
+	location, err := pokeapi.Location(name)
+
+	if err != nil {
+		plugin.Logger(ctx).Error("pokemon_location.getLocation", "query_error", err)
+		return nil, err
+	}
+
+	return location, nil
+}


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
 .inspect pokemon_location
+--------------+--------+----------------------------------------------------------------+
| column       | type   | description                                                    |
+--------------+--------+----------------------------------------------------------------+
| areas        | jsonb  | Areas that can be found in this location                       |
| game_indices | jsonb  | A list of game indices relevant to location item by generation |
| id           | bigint | The identifier for this resource.                              |
| name         | text   | The name for this resource.                                    |
| names        | jsonb  | Name of the region in different languages                      |
| title        | text   | Title of the resource.                                         |
+--------------+--------+----------------------------------------------------------------+
```

```
select name, id from pokemon_location
+----------------------------------+-----+
| name                             | id  |
+----------------------------------+-----+
| spring-path                      | 17  |
| canalave-city                    | 1   |
| solaceon-ruins                   | 12  |
| oreburgh-mine                    | 6   |
| ravaged-path                     | 14  |
| turnback-cave                    | 18  |
| wayward-cave                     | 20  |
| great-marsh                      | 11  |
| sunyshore-city                   | 4   |
| valley-windworks                 | 7   |
| eterna-forest                    | 8   |
| snowpoint-temple                 | 19  |
| fuego-ironworks                  | 9   |
| sinnoh-pokemon-league            | 5   |
| sinnoh-route-208                 | 38  |
| old-chateau                      | 25  |
| sinnoh-route-201                 | 31  |
| lost-tower                       | 40  |
| eterna-city                      | 2   |
| iron-island                      | 24  |
| mt-coronet                       | 10  |
| acuity-lakefront                 | 30  |
| valor-lakefront                  | 29  |
| sinnoh-route-209                 | 39  |
| lake-verity                      | 26  |
| oreburgh-gate                    | 15  |
| trophy-garden                    | 23  |
| stark-mountain                   | 16  |
| lake-valor                       | 27  |
| ruin-maniac-cave                 | 22  |
| sinnoh-route-207                 | 37  |
| sinnoh-route-210                 | 41  |
| sinnoh-route-203                 | 33  |
| sinnoh-route-204                 | 34  |
| lake-acuity                      | 28  |
| sinnoh-route-205                 | 35  |
| sinnoh-route-206                 | 36  |
| sinnoh-route-202                 | 32  |
| sinnoh-route-214                 | 45  |
| sinnoh-route-227                 | 55  |
| twinleaf-town                    | 58  |
| sinnoh-route-217                 | 48  |
| sinnoh-route-216                 | 47  |
| sinnoh-route-215                 | 46  |
| sinnoh-route-229                 | 57  |
| sinnoh-route-224                 | 53  |
```

```
select name, id, game_indices from pokemon_location where name = 'battle-park'
+-------------+-----+------------------------------------------------------------------------------------------------------------+
| name        | id  | game_indices                                                                                               |
+-------------+-----+------------------------------------------------------------------------------------------------------------+
| battle-park | 213 | [{"game_index":111,"generation":{"name":"generation-iv","url":"https://pokeapi.co/api/v2/generation/4/"}}] |
+-------------+-----+------------------------------------------------------------------------------------------------------------+
```
```
select name, id, game_indices from pokemon_location where id=214
+-----------------+-----+------------------------------------------------------------------------------------------------------------+
| name            | id  | game_indices                                                                                               |
+-----------------+-----+------------------------------------------------------------------------------------------------------------+
| battle-frontier | 214 | [{"game_index":112,"generation":{"name":"generation-iv","url":"https://pokeapi.co/api/v2/generation/4/"}}] |
+-----------------+-----+------------------------------------------------------------------------------------------------------------+
```
</details>
